### PR TITLE
Add python shebang

### DIFF
--- a/unpyc/unpyc3.py
+++ b/unpyc/unpyc3.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """
 Decompiler for Python3.7.
 Decompile a module or a function using the decompile() function


### PR DESCRIPTION
Add python shebang. This way you can call "unpyc3.py" after installation using `pip install .`.

Otherwise it will be interpreted as bash script on linux systems:
```
$ unpyc3.py
/home/me/envs/unpyc37/bin/unpyc3.py: line 22: $'\nDecompiler for Python3.7.\nDecompile a module or a function using the decompile() function\n\n>>> from unpyc3 import decompile\n>>> def foo(x, y, z=3, *args):\n...    global g\n...    for i, j in zip(x, y):\n...        if z == i + j or args[i] == j:\n...            g = i, j\n...            return\n...    \n>>> print(decompile(foo))\n\ndef foo(x, y, z=3, *args):\n    global g\n    for i, j in zip(x, y):\n        if z == i + j or args[i] == j:\n            g = i, j\n            return\n>>>\n': command not found
from: can't read /var/mail/typing
/home/me/envs/unpyc37/bin/unpyc3.py: line 28: import: command not found
/home/me/envs/unpyc37/bin/unpyc3.py: line 29: syntax error near unexpected token `code'
/home/me/envs/unpyc37/bin/unpyc3.py: line 29: `for opname, code in list(more_opcodes.opmap.items()):'
```