### PR TITLE
restore Python 3.7 compatibility

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.8
+    - name: Set up Python 3.7
       uses: actions/setup-python@v3
       with:
-        python-version: "3.8"
+        python-version: "3.7"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.1*.mod
 *.new
 *.bak
+.idea/
 venv/
 core
 .*_history

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ The original project is sadly no longer maintained.
 
 ### Examples
 To decompile a whole file:
-`python3.8 -m unpyc.unpyc3 file.pyc`
+`python3.7 -m unpyc.unpyc3 file.pyc`
 
 To decompile instructions 0-60:
-`python3.8 -m unpyc.unpyc3 file.pyc 0 60`
+`python3.7 -m unpyc.unpyc3 file.pyc 0 60`
 
 To decompile instructions 61 to end:
-`python3.8 -m unpyc.unpyc3 file.pyc 61`
+`python3.7 -m unpyc.unpyc3 file.pyc 61`
 
 ### Background
 The aim is to be able to recreate Python3 source code 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
+attrdict
 pytest
 pytest-env
 python-dotenv
 six
-


### PR DESCRIPTION
make the decompiler able to run in Python 3.7 again
fixes #27
I think Sourcery's configuration needs a fix to prevent this from happening again